### PR TITLE
Fix undefined identifiers and update theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'app_router.dart';
 import 'providers/settings_controller.dart';
+import 'data/question_repository.dart';
 import 'theme.dart';
 
 Future<void> main() async {

--- a/lib/screens/review_screen.dart
+++ b/lib/screens/review_screen.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/preferences_service.dart';
-import '../data/question_repository.dart';
 import '../models/question.dart';
 import '../providers/settings_controller.dart';
+import '../providers/quiz_controller.dart';
+import '../data/question_repository.dart';
 
 class ReviewScreen extends ConsumerWidget {
   const ReviewScreen({super.key});
@@ -40,7 +41,8 @@ class ReviewScreen extends ConsumerWidget {
 
   Future<(Set<String>, List<Question>)> _load(WidgetRef ref) async {
     final prefs = ref.read(preferencesServiceProvider);
-    final repo = ref.read(questionRepositoryProvider);
+    final QuestionRepository repo =
+        ref.read(questionRepositoryProvider);
     final locale = ref.read(settingsControllerProvider).locale;
     final mistakes = await prefs.getMistakes();
     final qs = await repo.load(locale);

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/settings_controller.dart';
 import '../services/preferences_service.dart';
+import '../data/question_repository.dart';
 
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
@@ -17,11 +18,13 @@ class SettingsScreen extends ConsumerWidget {
         children: [
           ListTile(
             title: Text('settings_language'.tr()),
-            trailing: DropdownButton(
+            trailing: DropdownButton<QuizLocale>(
               value: settings.locale,
-              onChanged: (val) => ref
-                  .read(settingsControllerProvider.notifier)
-                  .setLocale(val as QuizLocale),
+              onChanged: (val) => val == null
+                  ? null
+                  : ref
+                      .read(settingsControllerProvider.notifier)
+                      .setLocale(val),
               items: const [
                 DropdownMenuItem(value: QuizLocale.fr, child: Text('FR')),
                 DropdownMenuItem(value: QuizLocale.en, child: Text('EN')),

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -11,7 +11,7 @@ ThemeData buildTheme(bool dark) {
     ),
     textTheme: base.textTheme.apply(fontFamily: 'Roboto'),
     visualDensity: VisualDensity.comfortable,
-    cardTheme: const CardTheme(
+    cardTheme: const CardThemeData(
       margin: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
       elevation: 1,
       shape: RoundedRectangleBorder(


### PR DESCRIPTION
## Summary
- import `QuizLocale` definition where needed and type language dropdown
- connect review screen to `questionRepositoryProvider` and use typed repository
- update theme to use `CardThemeData` for M3 compatibility

## Testing
- `dart format lib/main.dart lib/screens/review_screen.dart lib/screens/settings_screen.dart lib/theme.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a186906e8832cbab44e8f1fe0faa5