### PR TITLE
Enhance results screen with gauge and retake option

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -13,6 +13,7 @@
   "results_score": "Score",
   "results_correct": "correct answers",
   "results_review": "Review mistakes",
+  "results_retry": "Retake quiz",
   "settings_title": "Settings",
   "settings_language": "Language",
   "settings_darkmode": "Dark mode",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -13,6 +13,7 @@
   "results_score": "Score",
   "results_correct": "bonnes réponses",
   "results_review": "Revoir les erreurs",
+  "results_retry": "Recommencer le quiz",
   "settings_title": "Réglages",
   "settings_language": "Langue",
   "settings_darkmode": "Mode sombre",

--- a/lib/screens/results_screen.dart
+++ b/lib/screens/results_screen.dart
@@ -12,6 +12,12 @@ class ResultsScreen extends ConsumerWidget {
     final s = ref.watch(quizControllerProvider);
     final score = s?.score ?? 0;
     final total = s?.total ?? 0;
+    final percent = total == 0 ? 0.0 : score / total;
+    final color = percent >= 0.8
+        ? Colors.green
+        : percent >= 0.5
+            ? Colors.orange
+            : Colors.red;
     return Scaffold(
       appBar: AppBar(title: Text('results_title'.tr())),
       body: Center(
@@ -22,12 +28,52 @@ class ResultsScreen extends ConsumerWidget {
               'results_score'.tr(),
               style: Theme.of(context).textTheme.headlineMedium,
             ),
-            const SizedBox(height: 8),
-            Text('$score / $total ${'results_correct'.tr()}'),
             const SizedBox(height: 16),
+            Stack(
+              alignment: Alignment.center,
+              children: [
+                SizedBox(
+                  height: 150,
+                  width: 150,
+                  child: CircularProgressIndicator(
+                    value: percent,
+                    strokeWidth: 12,
+                    backgroundColor:
+                        Theme.of(context).colorScheme.surfaceVariant,
+                    valueColor: AlwaysStoppedAnimation(color),
+                  ),
+                ),
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      percent >= 0.8
+                          ? Icons.emoji_events
+                          : Icons.sentiment_satisfied_alt,
+                      size: 48,
+                      color: color,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '$score / $total',
+                      style: Theme.of(context).textTheme.headlineMedium,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text('results_correct'.tr()),
+            const SizedBox(height: 24),
             FilledButton(
               onPressed: () => context.go('/review'),
               child: Text('results_review'.tr()),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton(
+              onPressed: () =>
+                  context.go('/quiz${total == 30 ? '?mode=exam' : ''}'),
+              child: Text('results_retry'.tr()),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- showcase quiz performance with circular progress gauge and celebratory icon
- add retake button for quickly starting a new quiz
- localize new UI strings in English and French

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a34d9409c832caeaacd185a919d19