### PR TITLE
Allow returning from review to results

### DIFF
--- a/lib/screens/results_screen.dart
+++ b/lib/screens/results_screen.dart
@@ -66,7 +66,7 @@ class ResultsScreen extends ConsumerWidget {
             Text('results_correct'.tr()),
             const SizedBox(height: 24),
             FilledButton(
-              onPressed: () => context.go('/review'),
+              onPressed: () => context.push('/review'),
               child: Text('results_review'.tr()),
             ),
             const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- Use `context.push` when navigating from results to review so users can return to the quiz results screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3d08570c832ca6935669a29bee29