### PR TITLE
Use named routes for clearer navigation

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -7,18 +7,42 @@ import 'screens/results_screen.dart';
 import 'screens/review_screen.dart';
 import 'screens/settings_screen.dart';
 
+/// Enum of all route names used throughout the app.
+enum AppRoute { splash, home, quiz, results, review, settings }
+
 final router = GoRouter(
   initialLocation: '/',
   routes: [
-    GoRoute(path: '/', builder: (_, __) => const SplashScreen()),
-    GoRoute(path: '/home', builder: (_, __) => const HomeScreen()),
+    GoRoute(
+      path: '/',
+      name: AppRoute.splash.name,
+      builder: (_, __) => const SplashScreen(),
+    ),
+    GoRoute(
+      path: '/home',
+      name: AppRoute.home.name,
+      builder: (_, __) => const HomeScreen(),
+    ),
     GoRoute(
       path: '/quiz',
+      name: AppRoute.quiz.name,
       builder: (_, state) =>
           QuizScreen(examMode: state.uri.queryParameters['mode'] == 'exam'),
     ),
-    GoRoute(path: '/results', builder: (_, __) => const ResultsScreen()),
-    GoRoute(path: '/review', builder: (_, __) => const ReviewScreen()),
-    GoRoute(path: '/settings', builder: (_, __) => const SettingsScreen()),
+    GoRoute(
+      path: '/results',
+      name: AppRoute.results.name,
+      builder: (_, __) => const ResultsScreen(),
+    ),
+    GoRoute(
+      path: '/review',
+      name: AppRoute.review.name,
+      builder: (_, __) => const ReviewScreen(),
+    ),
+    GoRoute(
+      path: '/settings',
+      name: AppRoute.settings.name,
+      builder: (_, __) => const SettingsScreen(),
+    ),
   ],
 );

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../app_router.dart';
 import '../providers/settings_controller.dart';
 
 class HomeScreen extends ConsumerWidget {
@@ -15,22 +16,28 @@ class HomeScreen extends ConsumerWidget {
       _HomeAction(
         label: 'home_start_quick'.tr(),
         icon: Icons.flash_on,
-        onTap: () => context.go('/quiz?mode=quick'),
+        onTap: () => context.goNamed(
+          AppRoute.quiz.name,
+          queryParameters: {'mode': 'quick'},
+        ),
       ),
       _HomeAction(
         label: 'home_start_exam'.tr(),
         icon: Icons.school,
-        onTap: () => context.go('/quiz?mode=exam'),
+        onTap: () => context.goNamed(
+          AppRoute.quiz.name,
+          queryParameters: {'mode': 'exam'},
+        ),
       ),
       _HomeAction(
         label: 'home_review_mistakes'.tr(),
         icon: Icons.refresh,
-        onTap: () => context.go('/review'),
+        onTap: () => context.goNamed(AppRoute.review.name),
       ),
       _HomeAction(
         label: 'home_settings'.tr(),
         icon: Icons.settings,
-        onTap: () => context.go('/settings'),
+        onTap: () => context.goNamed(AppRoute.settings.name),
       ),
     ];
 

--- a/lib/screens/quiz_screen.dart
+++ b/lib/screens/quiz_screen.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../app_router.dart';
 import '../providers/quiz_controller.dart';
 import '../widgets/question_card.dart';
 
@@ -103,6 +104,6 @@ class _QuizScreenState extends ConsumerState<QuizScreen> {
 
   void _finishOrNext(BuildContext context, bool finished) {
     ref.read(quizControllerProvider.notifier).next();
-    context.go('/results');
+    context.goNamed(AppRoute.results.name);
   }
 }

--- a/lib/screens/results_screen.dart
+++ b/lib/screens/results_screen.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../app_router.dart';
 import '../providers/quiz_controller.dart';
 
 class ResultsScreen extends ConsumerWidget {
@@ -66,13 +67,15 @@ class ResultsScreen extends ConsumerWidget {
             Text('results_correct'.tr()),
             const SizedBox(height: 24),
             FilledButton(
-              onPressed: () => context.push('/review'),
+              onPressed: () => context.pushNamed(AppRoute.review.name),
               child: Text('results_review'.tr()),
             ),
             const SizedBox(height: 8),
             OutlinedButton(
-              onPressed: () =>
-                  context.go('/quiz${total == 30 ? '?mode=exam' : ''}'),
+              onPressed: () => context.goNamed(
+                AppRoute.quiz.name,
+                queryParameters: total == 30 ? {'mode': 'exam'} : null,
+              ),
               child: Text('results_retry'.tr()),
             ),
           ],

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import '../app_router.dart';
 
 class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
@@ -13,7 +14,7 @@ class _SplashScreenState extends State<SplashScreen> {
     super.initState();
     Future.delayed(
       const Duration(milliseconds: 900),
-      () => context.go('/home'),
+      () => context.goNamed(AppRoute.home.name),
     );
   }
 


### PR DESCRIPTION
## Summary
- centralize route definitions with `AppRoute` enum
- navigate via named routes for home, quiz, results, review, and settings

## Testing
- `flutter format lib/app_router.dart lib/screens/home_screen.dart lib/screens/quiz_screen.dart lib/screens/results_screen.dart lib/screens/splash_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3dbde628832c82986637eb90d73e