### PR TITLE
Fix exam retry query parameters in results screen

### DIFF
--- a/lib/screens/results_screen.dart
+++ b/lib/screens/results_screen.dart
@@ -72,10 +72,12 @@ class ResultsScreen extends ConsumerWidget {
             ),
             const SizedBox(height: 8),
             OutlinedButton(
-              onPressed: () => context.goNamed(
-                AppRoute.quiz.name,
-                queryParameters: total == 30 ? {'mode': 'exam'} : null,
-              ),
+              onPressed: () => total == 30
+                  ? context.goNamed(
+                      AppRoute.quiz.name,
+                      queryParameters: {'mode': 'exam'},
+                    )
+                  : context.goNamed(AppRoute.quiz.name),
               child: Text('results_retry'.tr()),
             ),
           ],


### PR DESCRIPTION
## Summary
- ensure results screen retry button passes query parameters only in exam mode

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b94aacd70832cbe11ea0e348a19ec