### PR TITLE
Add home navigation from results screen

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -14,6 +14,7 @@
   "results_correct": "correct answers",
   "results_review": "Review mistakes",
   "results_retry": "Retake quiz",
+  "results_home": "Back to home",
   "settings_title": "Settings",
   "settings_language": "Language",
   "settings_darkmode": "Dark mode",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -14,6 +14,7 @@
   "results_correct": "bonnes réponses",
   "results_review": "Revoir les erreurs",
   "results_retry": "Recommencer le quiz",
+  "results_home": "Revenir à l'accueil",
   "settings_title": "Réglages",
   "settings_language": "Langue",
   "settings_darkmode": "Mode sombre",

--- a/lib/screens/results_screen.dart
+++ b/lib/screens/results_screen.dart
@@ -80,6 +80,11 @@ class ResultsScreen extends ConsumerWidget {
                   : context.goNamed(AppRoute.quiz.name),
               child: Text('results_retry'.tr()),
             ),
+            const SizedBox(height: 8),
+            TextButton(
+              onPressed: () => context.goNamed(AppRoute.home.name),
+              child: Text('results_home'.tr()),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- Add button on results screen to navigate back to home
- Provide English and French translations for new home button

## Testing
- `dart format lib/screens/results_screen.dart assets/i18n/en.json assets/i18n/fr.json` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b95d7c718832cbf209b29b452ae9f