### PR TITLE
Inject PreferencesService in settings and localize reset snackbar

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -19,6 +19,7 @@
   "settings_language": "Language",
   "settings_darkmode": "Dark mode",
   "settings_reset": "Reset progress",
+  "settings_reset_done": "Progress reset.",
   "dialog_confirm": "Confirm",
   "dialog_cancel": "Cancel"
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -19,6 +19,7 @@
   "settings_language": "Langue",
   "settings_darkmode": "Mode sombre",
   "settings_reset": "Réinitialiser les progrès",
+  "settings_reset_done": "Progrès réinitialisés.",
   "dialog_confirm": "Confirmer",
   "dialog_cancel": "Annuler"
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -2,7 +2,6 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/settings_controller.dart';
-import '../services/preferences_service.dart';
 import '../data/question_repository.dart';
 
 class SettingsScreen extends ConsumerWidget {
@@ -57,11 +56,13 @@ class SettingsScreen extends ConsumerWidget {
                 ),
               );
               if (ok == true) {
-                await PreferencesService().resetAll();
+                await ref.read(preferencesServiceProvider).resetAll();
                 // ignore: use_build_context_synchronously
                 ScaffoldMessenger.of(
                   context,
-                ).showSnackBar(const SnackBar(content: Text('Reset done.')));
+                ).showSnackBar(
+                  SnackBar(content: Text('settings_reset_done'.tr())),
+                );
               }
             },
             child: Text('settings_reset'.tr()),


### PR DESCRIPTION
## Summary
- inject PreferencesService via provider instead of direct instantiation
- show localized snackbar after resetting settings
- add translations for reset confirmation

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/screens/settings_screen.dart assets/i18n/en.json assets/i18n/fr.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b9f098ee0832ca2f7225cc0c96383