### PR TITLE
Add universal back navigation button

### DIFF
--- a/lib/screens/quiz_screen.dart
+++ b/lib/screens/quiz_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../app_router.dart';
 import '../providers/quiz_controller.dart';
 import '../widgets/question_card.dart';
+import '../widgets/app_back_button.dart';
 
 class QuizScreen extends ConsumerStatefulWidget {
   final bool examMode;
@@ -35,6 +36,7 @@ class _QuizScreenState extends ConsumerState<QuizScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        leading: const AppBackButton(),
         title: Text(
           'quiz_question'.tr(
             namedArgs: {'index': '${s.index + 1}', 'total': '${s.total}'},

--- a/lib/screens/results_screen.dart
+++ b/lib/screens/results_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../app_router.dart';
 import '../providers/quiz_controller.dart';
+import '../widgets/app_back_button.dart';
 
 class ResultsScreen extends ConsumerWidget {
   const ResultsScreen({super.key});
@@ -20,7 +21,10 @@ class ResultsScreen extends ConsumerWidget {
             ? Colors.orange
             : Colors.red;
     return Scaffold(
-      appBar: AppBar(title: Text('results_title'.tr())),
+      appBar: AppBar(
+        leading: const AppBackButton(),
+        title: Text('results_title'.tr()),
+      ),
       body: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,

--- a/lib/screens/review_screen.dart
+++ b/lib/screens/review_screen.dart
@@ -5,6 +5,7 @@ import '../models/question.dart';
 import '../providers/settings_controller.dart';
 import '../providers/quiz_controller.dart';
 import '../data/question_repository.dart';
+import '../widgets/app_back_button.dart';
 
 class ReviewScreen extends ConsumerWidget {
   const ReviewScreen({super.key});
@@ -12,7 +13,10 @@ class ReviewScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Review')),
+      appBar: AppBar(
+        leading: const AppBackButton(),
+        title: const Text('Review'),
+      ),
       body: FutureBuilder<(Set<String>, List<Question>)>(
         future: _load(ref),
         builder: (context, snapshot) {

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/settings_controller.dart';
 import '../data/question_repository.dart';
+import '../widgets/app_back_button.dart';
 
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
@@ -11,7 +12,10 @@ class SettingsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final settings = ref.watch(settingsControllerProvider);
     return Scaffold(
-      appBar: AppBar(title: Text('settings_title'.tr())),
+      appBar: AppBar(
+        leading: const AppBackButton(),
+        title: Text('settings_title'.tr()),
+      ),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [

--- a/lib/widgets/app_back_button.dart
+++ b/lib/widgets/app_back_button.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../app_router.dart';
+
+class AppBackButton extends StatelessWidget {
+  const AppBackButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BackButton(
+      onPressed: () {
+        if (Navigator.of(context).canPop()) {
+          context.pop();
+        } else {
+          context.goNamed(AppRoute.home.name);
+        }
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce `AppBackButton` widget that returns to previous route or home
- Add back navigation to quiz, review, results, and settings screens

## Testing
- `dart format lib/widgets/app_back_button.dart lib/screens/review_screen.dart lib/screens/settings_screen.dart lib/screens/quiz_screen.dart lib/screens/results_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ba952c76c832c8b37d07a737859ab