### PR TITLE
Use asset logo in splash screen

### DIFF
--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -20,6 +20,14 @@ class _SplashScreenState extends State<SplashScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(body: Center(child: FlutterLogo(size: 96)));
+    return Scaffold(
+      body: Center(
+        child: Image.asset(
+          'assets/app_logo.png',
+          width: 96,
+          height: 96,
+        ),
+      ),
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,3 +38,4 @@ flutter:
     - assets/i18n/fr.json
     - assets/questions/en.json
     - assets/questions/fr.json
+    - assets/app_logo.png


### PR DESCRIPTION
## Summary
- load app logo from assets in splash screen
- register new app_logo.png asset in pubspec

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c8dc1d29c832ca1f126fb2fd12c0f