### PR TITLE
Fix hearts controller provider reference and null safety

### DIFF
--- a/lib/providers/heart_controller.dart
+++ b/lib/providers/heart_controller.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../services/preferences_service.dart';
+import 'settings_controller.dart';
 
 class HeartsState {
   final int hearts;
@@ -41,16 +41,13 @@ class HeartsController extends StateNotifier<HeartsState> {
     var hearts = state.hearts;
     DateTime? next = state.nextRegen;
     final now = DateTime.now();
-    if (next != null) {
-      while (!now.isBefore(next)) {
-        hearts++;
-        if (hearts >= maxHearts) {
-          hearts = maxHearts;
-          next = null;
-          break;
-        } else {
-          next = next.add(regenDuration);
-        }
+    while (next != null && !now.isBefore(next)) {
+      hearts++;
+      if (hearts >= maxHearts) {
+        hearts = maxHearts;
+        next = null;
+      } else {
+        next = next!.add(regenDuration);
       }
     }
     state = HeartsState(hearts: hearts, nextRegen: next);


### PR DESCRIPTION
## Summary
- import preferences service provider for hearts controller
- handle nullable next regeneration time safely

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cee2dddc8832cb4d37d113c366a62