### PR TITLE
feat: brand color scheme and text styles

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -113,7 +113,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     ];
 
     return Scaffold(
-      appBar: AppBar(title: Text('app_title'.tr())),
+      appBar: AppBar(
+        title: Text(
+          'app_title'.tr(),
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+      ),
       body: Column(
         children: [
           Expanded(
@@ -131,7 +136,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                           i < hearts.hearts
                               ? Icons.favorite
                               : Icons.favorite_border,
-                          color: Colors.red,
+                          color:
+                              Theme.of(context).colorScheme.secondary,
                         ),
                       ),
                       IconButton(
@@ -139,15 +145,19 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                         padding: EdgeInsets.zero,
                         icon: Stack(
                           alignment: Alignment.center,
-                          children: const [
-                            Icon(Icons.favorite, color: Colors.red),
+                          children: [
+                            Icon(
+                              Icons.favorite,
+                              color: Theme.of(context).colorScheme.secondary,
+                            ),
                             Positioned(
                               right: 0,
                               bottom: 0,
                               child: Icon(
                                 Icons.add,
                                 size: 12,
-                                color: Colors.white,
+                                color:
+                                    Theme.of(context).colorScheme.onSecondary,
                               ),
                             ),
                           ],
@@ -225,6 +235,7 @@ class _ActionCard extends StatelessWidget {
               Text(
                 action.label,
                 textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.titleLarge,
               ),
             ],
           ),

--- a/lib/screens/quiz_screen.dart
+++ b/lib/screens/quiz_screen.dart
@@ -41,6 +41,7 @@ class _QuizScreenState extends ConsumerState<QuizScreen> {
           'quiz_question'.tr(
             namedArgs: {'index': '${s.index + 1}', 'total': '${s.total}'},
           ),
+          style: Theme.of(context).textTheme.titleLarge,
         ),
       ),
       body: Padding(
@@ -93,6 +94,7 @@ class _QuizScreenState extends ConsumerState<QuizScreen> {
                       s.index == s.total - 1
                           ? 'quiz_finish'.tr()
                           : 'quiz_next'.tr(),
+                      style: Theme.of(context).textTheme.titleLarge,
                     ),
                   ),
                 ),

--- a/lib/screens/results_screen.dart
+++ b/lib/screens/results_screen.dart
@@ -51,15 +51,19 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
     final score = s?.score ?? 0;
     final total = s?.total ?? 0;
     final percent = total == 0 ? 0.0 : score / total;
+    final scheme = Theme.of(context).colorScheme;
     final color = percent >= 0.8
-        ? Colors.green
+        ? scheme.primary
         : percent >= 0.5
-            ? Colors.orange
-            : Colors.red;
+            ? scheme.tertiary
+            : scheme.secondary;
     return Scaffold(
       appBar: AppBar(
         leading: const AppBackButton(),
-        title: Text('results_title'.tr()),
+        title: Text(
+          'results_title'.tr(),
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
       ),
       body: Center(
         child: Column(
@@ -104,7 +108,10 @@ class _ResultsScreenState extends ConsumerState<ResultsScreen> {
               ],
             ),
             const SizedBox(height: 8),
-            Text('results_correct'.tr()),
+            Text(
+              'results_correct'.tr(),
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
             const SizedBox(height: 24),
             FilledButton(
               onPressed: () => context.pushNamed(AppRoute.review.name),

--- a/lib/screens/review_screen.dart
+++ b/lib/screens/review_screen.dart
@@ -15,7 +15,10 @@ class ReviewScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         leading: const AppBackButton(),
-        title: const Text('Review'),
+        title: Text(
+          'Review',
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
       ),
       body: FutureBuilder<(Set<String>, List<Question>)>(
         future: _load(ref),
@@ -27,14 +30,25 @@ class ReviewScreen extends ConsumerWidget {
               .where((q) => mistakes.contains(q.id))
               .toList();
           if (filtered.isEmpty)
-            return const Center(child: Text('Aucune erreur enregistrée.'));
+            return Center(
+              child: Text(
+                'Aucune erreur enregistrée.',
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            );
           return ListView.builder(
             itemCount: filtered.length,
             itemBuilder: (_, i) {
               final q = filtered[i];
               return ListTile(
-                title: Text(q.prompt),
-                subtitle: Text(q.explanation ?? ''),
+                title: Text(
+                  q.prompt,
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                subtitle: Text(
+                  q.explanation ?? '',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
               );
             },
           );

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -15,13 +15,19 @@ class SettingsScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         leading: const AppBackButton(),
-        title: Text('settings_title'.tr()),
+        title: Text(
+          'settings_title'.tr(),
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
           ListTile(
-            title: Text('settings_language'.tr()),
+            title: Text(
+              'settings_language'.tr(),
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
             trailing: DropdownButton<QuizLocale>(
               value: settings.locale,
               onChanged: (val) => val == null
@@ -36,7 +42,10 @@ class SettingsScreen extends ConsumerWidget {
             ),
           ),
           SwitchListTile(
-            title: Text('settings_darkmode'.tr()),
+            title: Text(
+              'settings_darkmode'.tr(),
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
             value: settings.darkMode,
             onChanged: (v) =>
                 ref.read(settingsControllerProvider.notifier).toggleDark(v),
@@ -47,15 +56,24 @@ class SettingsScreen extends ConsumerWidget {
               final ok = await showDialog<bool>(
                 context: context,
                 builder: (_) => AlertDialog(
-                  title: Text('dialog_confirm'.tr()),
+                  title: Text(
+                    'dialog_confirm'.tr(),
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
                   actions: [
                     TextButton(
                       onPressed: () => Navigator.pop(context, false),
-                      child: Text('dialog_cancel'.tr()),
+                      child: Text(
+                        'dialog_cancel'.tr(),
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
                     ),
                     FilledButton(
                       onPressed: () => Navigator.pop(context, true),
-                      child: Text('dialog_confirm'.tr()),
+                      child: Text(
+                        'dialog_confirm'.tr(),
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
                     ),
                   ],
                 ),
@@ -71,7 +89,10 @@ class SettingsScreen extends ConsumerWidget {
                 );
               }
             },
-            child: Text('settings_reset'.tr()),
+            child: Text(
+              'settings_reset'.tr(),
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
           ),
         ],
       ),

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -2,17 +2,42 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 ThemeData buildTheme(bool dark) {
+  // Brand colors
+  const primary = Color(0xFF0055A4);
+  const secondary = Color(0xFFEF4135);
+  const neutral = Color(0xFF6C757D);
+
   final scheme = ColorScheme.fromSeed(
-    seedColor: const Color(0xFF0055A4),
-    secondary: const Color(0xFFEF4135),
+    seedColor: primary,
+    secondary: secondary,
+    tertiary: neutral,
     brightness: dark ? Brightness.dark : Brightness.light,
+  ).copyWith(
+    onPrimary: Colors.white,
+    onSecondary: Colors.white,
+    onTertiary: dark ? Colors.black : Colors.white,
   );
+
   final baseTextTheme =
       (dark ? ThemeData.dark() : ThemeData.light()).textTheme;
+  final textTheme = GoogleFonts.montserratTextTheme(baseTextTheme).copyWith(
+    headlineMedium: GoogleFonts.montserrat(
+      textStyle: baseTextTheme.headlineMedium,
+      fontWeight: FontWeight.bold,
+    ),
+    titleLarge: GoogleFonts.montserrat(
+      textStyle: baseTextTheme.titleLarge,
+      fontWeight: FontWeight.w600,
+    ),
+    bodyMedium: GoogleFonts.montserrat(
+      textStyle: baseTextTheme.bodyMedium,
+    ),
+  );
+
   return ThemeData(
     useMaterial3: true,
     colorScheme: scheme,
-    textTheme: GoogleFonts.montserratTextTheme(baseTextTheme),
+    textTheme: textTheme,
     visualDensity: VisualDensity.comfortable,
     cardTheme: const CardThemeData(
       margin: EdgeInsets.symmetric(vertical: 8, horizontal: 12),


### PR DESCRIPTION
## Summary
- define project color scheme and text styles using GoogleFonts
- refactor screens to use Theme color scheme instead of hard coded values
- apply consistent typography across screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cf8764880832cabada616890b2edc