### PR TITLE
Enhance splash screen with animated logo and gradient

### DIFF
--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -9,9 +9,17 @@ class SplashScreen extends StatefulWidget {
 }
 
 class _SplashScreenState extends State<SplashScreen> {
+  bool _visible = false;
+
   @override
   void initState() {
     super.initState();
+    // Trigger the fade-in animation for the logo.
+    Future.delayed(Duration.zero, () {
+      setState(() {
+        _visible = true;
+      });
+    });
     Future.delayed(
       const Duration(milliseconds: 900),
       () => context.goNamed(AppRoute.home.name),
@@ -21,11 +29,37 @@ class _SplashScreenState extends State<SplashScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Center(
-        child: Image.asset(
-          'assets/app_logo.png',
-          width: 96,
-          height: 96,
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [
+              Theme.of(context).colorScheme.primary,
+              Theme.of(context).colorScheme.secondary,
+            ],
+          ),
+        ),
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AnimatedOpacity(
+                opacity: _visible ? 1.0 : 0.0,
+                duration: const Duration(milliseconds: 900),
+                child: Image.asset(
+                  'assets/app_logo.png',
+                  width: 96,
+                  height: 96,
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Citoyenneté France — Quiz & Test',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- Replace the splash screen's plain background with a gradient and center-aligned content
- Fade the logo in over 900ms and display a brand tagline beneath it

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cfcc1a1c0832c9c5895b4df1f356e