### PR TITLE
style: unify filled button appearance

### DIFF
--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -50,6 +50,19 @@ ThemeData buildTheme(bool dark) {
     colorScheme: scheme,
     textTheme: textTheme,
     visualDensity: VisualDensity.comfortable,
+    filledButtonTheme: FilledButtonThemeData(
+      style: ButtonStyle(
+        backgroundColor: WidgetStatePropertyAll(scheme.primary),
+        foregroundColor: WidgetStatePropertyAll(scheme.onPrimary),
+        overlayColor:
+            WidgetStatePropertyAll(scheme.onPrimary.withOpacity(0.1)),
+        shape: WidgetStatePropertyAll(
+          const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(16)),
+          ),
+        ),
+      ),
+    ),
     extensions: [statusColors],
     cardTheme: const CardThemeData(
       margin: EdgeInsets.symmetric(vertical: 8, horizontal: 12),

--- a/lib/widgets/primary_button.dart
+++ b/lib/widgets/primary_button.dart
@@ -15,12 +15,6 @@ class PrimaryButton extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 6),
       child: FilledButton(
         onPressed: onPressed,
-        style: FilledButton.styleFrom(
-          minimumSize: const Size.fromHeight(52),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
-        ),
         child: Text(label),
       ),
     );


### PR DESCRIPTION
## Summary
- introduce `FilledButtonThemeData` to centralize button colors and shape
- streamline `PrimaryButton` to use themed styles

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d019c0678832c81995fbb16227bad