### PR TITLE
Refine theme and answer feedback

### DIFF
--- a/lib/screens/quiz_screen.dart
+++ b/lib/screens/quiz_screen.dart
@@ -85,7 +85,7 @@ class _QuizScreenState extends ConsumerState<QuizScreen> {
             Row(
               children: [
                 Expanded(
-                  child: ElevatedButton(
+                  child: FilledButton(
                     onPressed: s.index == s.total - 1
                         ? () => _finishOrNext(context)
                         : () =>

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -51,7 +51,7 @@ class SettingsScreen extends ConsumerWidget {
                 ref.read(settingsControllerProvider.notifier).toggleDark(v),
           ),
           const Divider(),
-          ElevatedButton(
+          FilledButton(
             onPressed: () async {
               final ok = await showDialog<bool>(
                 context: context,

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -4,10 +4,10 @@ import 'package:google_fonts/google_fonts.dart';
 import 'theme_extensions.dart';
 
 ThemeData buildTheme(bool dark) {
-  // Brand colors
-  const primary = Color(0xFF003A70);
-  const secondary = Color(0xFFE64545);
-  const neutral = Color(0xFF64748B);
+  // Brand colors (professional palette)
+  const primary = Color(0xFF1E3A8A); // deep navy
+  const secondary = Color(0xFFC5A880); // warm gold
+  const neutral = Color(0xFF4B5563); // cool gray
 
   Color onColor(Color color) =>
       color.computeLuminance() > 0.5 ? Colors.black : Colors.white;
@@ -24,8 +24,8 @@ ThemeData buildTheme(bool dark) {
   );
 
   final statusColors = StatusColors(
-    success: const Color(0xFF4CAF50),
-    warning: const Color(0xFFFFC107),
+    success: const Color(0xFF2E7D32), // refined green
+    warning: const Color(0xFFED6C02), // amber tone
     error: scheme.error,
   );
 

--- a/lib/widgets/question_card.dart
+++ b/lib/widgets/question_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/question.dart';
+import '../theme_extensions.dart';
 
 class QuestionCard extends StatelessWidget {
   final Question question;
@@ -26,43 +27,50 @@ class QuestionCard extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             ...List.generate(question.choices.length, (i) {
+              final status =
+                  Theme.of(context).extension<StatusColors>()!;
+              final isAnswered = selectedIndex != null;
               final isSelected = selectedIndex == i;
+              final isCorrect = question.answerIndex == i;
+
+              Color borderColor = Theme.of(context).dividerColor;
+              Color? fillColor;
+              Color activeColor = Theme.of(context).colorScheme.primary;
+
+              if (isAnswered) {
+                if (isCorrect) {
+                  borderColor = status.success;
+                  fillColor = status.success.withOpacity(0.1);
+                  activeColor = status.success;
+                } else if (isSelected) {
+                  borderColor = status.error;
+                  fillColor = status.error.withOpacity(0.1);
+                  activeColor = status.error;
+                }
+              } else if (isSelected) {
+                borderColor = Theme.of(context).colorScheme.primary;
+                fillColor = Theme.of(context)
+                    .colorScheme
+                    .primary
+                    .withOpacity(0.1);
+              }
+
               return AnimatedContainer(
                 duration: const Duration(milliseconds: 200),
                 margin: const EdgeInsets.symmetric(vertical: 4),
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(12),
-                  color: isSelected
-                      ? Theme.of(context)
-                          .colorScheme
-                          .primary
-                          .withOpacity(0.1)
-                      : null,
-                  border: Border.all(
-                    color: isSelected
-                        ? Theme.of(context).colorScheme.primary
-                        : Theme.of(context).dividerColor,
-                  ),
-                  boxShadow: isSelected
-                      ? [
-                          BoxShadow(
-                            color: Theme.of(context)
-                                .colorScheme
-                                .primary
-                                .withOpacity(0.3),
-                            blurRadius: 4,
-                            offset: const Offset(0, 2),
-                          ),
-                        ]
-                      : [],
+                  color: fillColor,
+                  border: Border.all(color: borderColor),
                 ),
                 child: RadioListTile<int>(
                   value: i,
                   groupValue: selectedIndex,
-                  onChanged: (val) => onSelected(val!),
+                  onChanged:
+                      isAnswered ? null : (val) => onSelected(val!),
                   title: Text(question.choices[i]),
                   controlAffinity: ListTileControlAffinity.leading,
-                  activeColor: Theme.of(context).colorScheme.primary,
+                  activeColor: activeColor,
                   contentPadding:
                       const EdgeInsets.symmetric(horizontal: 12),
                 ),


### PR DESCRIPTION
## Summary
- adopt a refined navy and gold color palette
- switch primary actions to FilledButton for cohesive styling
- highlight correct answers in green and incorrect selections in red

## Testing
- `dart format lib/theme.dart lib/widgets/question_card.dart lib/screens/quiz_screen.dart lib/screens/settings_screen.dart` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repositories not signed)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aa9be2d8832cba8d6dc949cb3698